### PR TITLE
Adding additonal role (common) to perform basic tasks on all nodes.

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Install and Update Python
+  raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal)"
+ 

--- a/site.yml
+++ b/site.yml
@@ -1,9 +1,15 @@
 ---
 # This playbook deploys a simple kubeadm install.
+- name: Bootstrap Tasks
+  hosts: all
+  remote_user: ubuntu
+  gather_facts: False
+  roles:
+    - common
 
 - name: Install Kubernetes master
   hosts: master
-  remote_user: ben
+  remote_user: ubuntu
   become: yes
   become_method: sudo
   roles:
@@ -12,7 +18,7 @@
     - master
 
 - name: Install nodes
-  remote_user: ben
+  remote_user: ubuntu
   hosts: slaves
   become: yes
   become_method: sudo


### PR DESCRIPTION
First task is to check for and install python. This is a prerequisite for ansible.
Some installations of ubuntu don't have python installed by default.
The "raw" command bypasses the need for python to execute. It checks for the existance first,
so it can be run multiple times without conflict.