### PR TITLE
Hotfix/portmap missing from kubernetes cni

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Install and Update Python
+  raw: sudo bash -c "test -e /usr/bin/python || (apt -qqy update && apt install -qy python-minimal)"
+ 

--- a/roles/kubeadm/tasks/main.yml
+++ b/roles/kubeadm/tasks/main.yml
@@ -22,3 +22,10 @@
     - kubeadm
     - kubectl
     - kubernetes-cni
+
+# Download portmap because kubernetes-cni does not include but flannel needs
+- name: download portmap
+  get_url:
+        url: https://github.com/projectcalico/cni-plugin/releases/download/v1.9.1/portmap
+        dest: /opt/cni/bin/portmap
+        mode: 0755

--- a/site.yml
+++ b/site.yml
@@ -1,9 +1,15 @@
 ---
 # This playbook deploys a simple kubeadm install.
+- name: Bootstrap Tasks
+  hosts: all
+  remote_user: ubuntu
+  gather_facts: False
+  roles:
+    - common
 
 - name: Install Kubernetes master
   hosts: master
-  remote_user: ben
+  remote_user: ubuntu
   become: yes
   become_method: sudo
   roles:
@@ -12,7 +18,7 @@
     - master
 
 - name: Install nodes
-  remote_user: ben
+  remote_user: ubuntu
   hosts: slaves
   become: yes
   become_method: sudo


### PR DESCRIPTION
Due to bug in coreos/flannel (coreos/flannel#890) the downloaded template from
https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml requires portmap.
Because flannel requires but kubernetes-cni does not install, it needs to be manually copied to /opt/cni/bin/portmap
If portmap is not in place the symptom is the kube-dns will be stuck in CreatingContainer.
This additional task should be temp until either flannel no longer requires portmap or kubernetes-cni installs by default.