### PR TITLE
Added task to copy kubeconfig from /etc/kubernetes/admin.conf to $HOME

### DIFF
--- a/roles/master/tasks/main.yml
+++ b/roles/master/tasks/main.yml
@@ -20,6 +20,18 @@
 - name: install flannel pod network
   command: kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 
+- name: copy config file to HOME dir
+  command: "{{ item }}"
+  with_items:
+    - cp /etc/kubernetes/admin.conf ~{{ansible_remote_user }}/admin.conf
+    - chown {{ ansible_remote_user }}:{{ ansible_remote_user }} ~{{ansible_remote_user }}/admin.conf
+    - chmod 0400 ~{{ansible_remote_user }}/admin.conf
+
+- name: write KUBECONFGIG to bashrc
+  lineinfile: dest="~{{ansible_remote_user }}/.bashrc" line="{{item}}"
+  with_items:
+     - "export KUBECONFIG=$HOME/admin.conf"
+
 - pause:
     minutes: 3
     prompt: "Make sure network pods are started"


### PR DESCRIPTION
Added task to copy kubeconfig from /etc/kubernetes/admin.conf to $HOME/admin.conf, then add KUBECONFIG env to .bashrc. This allows kubectl to work without sudo and without
calling --kubeconfig /etc/kubernetes/admin.conf on every command.
This task is only on the master.

The "command" task was needed because of file permissions when using "file" tasks. A warning is given during runtime, but no errors. 