### PR TITLE
Use gathered facts to populate master_ip

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,8 +1,8 @@
 
 kubeadm_token: decaf2.c61dd19a426515ec
 
-master_ip: 192.168.56.10
+master_ip: "{{ hostvars['master1']['ansible_eth0']['ipv4']['address'] }}"
 
 flannel_subnet: 10.244.0.0/16
 
-ansible_remote_user: ben
+ansible_remote_user: ubuntu

--- a/inventory
+++ b/inventory
@@ -1,7 +1,18 @@
 
 [master]
-192.168.56.10
+master1 ansible_ssh_host=192.168.56.10
 
 [slaves]
 192.168.56.11
 192.168.56.12
+
+# To bypass the interactive acceptance of host keys enable the following options.
+# This is an additional security risk, so be sure you are on a secure network.
+# This can be useful if the targets were provisioned automatically and the ansible 
+# host has not logged into the targets before.
+
+# [master:vars]
+# ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+#
+# [slaves:vars]
+# ansible_ssh_common_args='-o StrictHostKeyChecking=no'


### PR DESCRIPTION
If you are using a different IP network than the SSH IP you need to get it and remember to add it to group vars.
Used the gathered facts to populate the master_ip address.  Assume eth0.

Also added commented out options to ignore host checking. This way ansible does not fail on first run if the host key has not been accepted. 